### PR TITLE
[BugFix] Door sampling infinite loop

### DIFF
--- a/procthor/generation/doors.py
+++ b/procthor/generation/doors.py
@@ -264,8 +264,9 @@ def select_openings(
 
         # NOTE: indexes that still need connecting rooms
         need_connections_between = list(range(len(group_neighbors)))
-        while need_connections_between:
-            next_room_i = random.choice(need_connections_between)
+        for next_room_i in range(len(group_neighbors)):
+            if next_room_i not in need_connections_between:
+                continue
             other_room_is = [i for i in range(len(group_neighbors)) if i != next_room_i]
             random.shuffle(other_room_is)
             n1_subgroup = group_neighbors[next_room_i]


### PR DESCRIPTION
### Description

This PR fixes - 

- [x] Infinite loop in door sampling logic

Sample failure case:

```
group_neighbors: [{4}, {5}]
neighboring_rooms: {(4, 9), (8, 9), (1, 6), (2, 5), (1, 3), (6, 8), (5, 6), (4, 8), (3, 6), (5, 9), (2, 4), $
1, 2), (1, 8), (6, 7), (1, 4), (2, 3), (2, 9), (1, 7), (2, 6), (7, 8)}
```